### PR TITLE
Workaround for alarm reliability issues

### DIFF
--- a/app/src/main/java/de/kathrin/angebote/NotificationActivity.java
+++ b/app/src/main/java/de/kathrin/angebote/NotificationActivity.java
@@ -206,11 +206,11 @@ public class NotificationActivity extends AppCompatActivity {
             AlarmHandler.setAlarm(this, date);
 
         } else {
-            // Set alarm to next monday and update file
-            Calendar nextMonday = NotificationUtils.getNextMonday();
-            AlarmHandler.setAlarm(this, nextMonday);
-            NotificationUtils.writeAlarmToFile(this, nextMonday);
-            Log.v(LOG_TAG, "Setting new alarm to " + nextMonday.getTime());
+            // Set alarm to next day and update file
+            Calendar date = NotificationUtils.getTomorrow();
+            AlarmHandler.setAlarm(this, date);
+            NotificationUtils.writeAlarmToFile(this, date);
+            Log.v(LOG_TAG, "Setting new alarm to " + date.getTime());
         }
     }
 }

--- a/app/src/main/java/de/kathrin/angebote/utlis/NotificationUtils.java
+++ b/app/src/main/java/de/kathrin/angebote/utlis/NotificationUtils.java
@@ -37,6 +37,20 @@ public class NotificationUtils {
     }
 
     /**
+     * Create a Calendar instance having the next day, 9 o'clock as a date.
+     * @return  Calendar instance
+     */
+    public static Calendar getTomorrow () {
+        Calendar date = Calendar.getInstance();
+        date.set(Calendar.HOUR_OF_DAY, 9);
+        date.set(Calendar.MINUTE, 0);
+        date.set(Calendar.SECOND, 0);
+        date.add(Calendar.DAY_OF_YEAR, 1);
+        return date;
+
+    }
+
+    /**
      * Restore the alarm date from the file
      * @param context   current context
      * @return  Calender instance, date read from the file


### PR DESCRIPTION
Alarms don't reliably fire on mondays. To try and work around this issue, set a new alarm every day but only show the notifications on mondays.
Also replaced the 20s wait after checkForNewOffers() with a call in the onPostExecute() of the async task.